### PR TITLE
Minor lancet fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ coordinator:
 
 agents: clean
 	mkdir agents/assets
-	cmake -DCMAKE_BUILD_TYPE=Debug -S . -B agents/assets
+	cmake -DCMAKE_BUILD_TYPE=Release -S . -B agents/assets
 	cmake	--build agents/assets
 
 agents_r2p2: clean

--- a/inc/lancet/agent.h
+++ b/inc/lancet/agent.h
@@ -53,7 +53,7 @@ enum transport_protocol_type {
 struct agent_config {
 	int thread_count;
 	int conn_count;
-	struct host_tuple targets[64];
+	struct host_tuple targets[8192];
 	int target_count;
 	enum agent_type atype;
 	enum transport_protocol_type tp_type;


### PR DESCRIPTION
Minor but important fixes for production-like deployment:
* increased the number of target servers from 64 to 8192
* changed agents build type to Release (enables compiler optimizations)